### PR TITLE
Clean up `RSpec/OverwritingSetup` violations - with one todo for DAL

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,6 +10,3 @@ inherit_from:
 RSpec/NestedGroups:
   Exclude:
     - 'spec/lib/airship/api/base_spec.rb'
-
-RSpec/OverwritingSetup:
-  Enabled: false

--- a/spec/lib/airship/api/email_channel_create_spec.rb
+++ b/spec/lib/airship/api/email_channel_create_spec.rb
@@ -96,11 +96,6 @@ RSpec.describe Airship::Api::EmailChannelCreate do
       '{"ok":false,"error":"Unauthorized","error_code":40101}'
     end
 
-    let(:response_status) { 401 }
-    let(:response_body) do
-      '{"ok":false,"error":"Unauthorized","error_code":40101}'
-    end
-
     it 'is expected not to succeed' do
       expect { subject }.to raise_error Airship::Api::Unauthorized
     end

--- a/spec/lib/airship/api/email_channel_uninstall_spec.rb
+++ b/spec/lib/airship/api/email_channel_uninstall_spec.rb
@@ -81,11 +81,6 @@ RSpec.describe Airship::Api::EmailChannelUninstall do
       '{"ok":false,"error":"Unauthorized","error_code":40101}'
     end
 
-    let(:response_status) { 401 }
-    let(:response_body) do
-      '{"ok":false,"error":"Unauthorized","error_code":40101}'
-    end
-
     it 'is expected not to succeed' do
       expect { subject }.to raise_error Airship::Api::Unauthorized
     end

--- a/spec/lib/airship/api/email_channel_update_spec.rb
+++ b/spec/lib/airship/api/email_channel_update_spec.rb
@@ -86,11 +86,6 @@ RSpec.describe Airship::Api::EmailChannelUpdate do
       '{"ok":false,"error":"Unauthorized","error_code":40101}'
     end
 
-    let(:response_status) { 401 }
-    let(:response_body) do
-      '{"ok":false,"error":"Unauthorized","error_code":40101}'
-    end
-
     it 'is expected not to succeed' do
       expect { subject }.to raise_error Airship::Api::Unauthorized
     end

--- a/spec/lib/airship/api/named_user_associate_email_spec.rb
+++ b/spec/lib/airship/api/named_user_associate_email_spec.rb
@@ -78,6 +78,8 @@ RSpec.describe Airship::Api::NamedUserAssociateEmail do
     subject
   end
 
+  # rubocop:disable RSpec/OverwritingSetup
+  # TODO: Fix this test!
   context 'when failing with HTTP status-code 400 and missing channel' do
     let(:response_status) { 400 }
     let(:response_body) do
@@ -99,13 +101,9 @@ RSpec.describe Airship::Api::NamedUserAssociateEmail do
       expect { subject }.to raise_error Airship::Api::Unauthorized
     end
   end
+  # rubocop:enable RSpec/OverwritingSetup
 
   context 'when responding with any failing HTTP status-code' do
-    let(:response_status) { 401 }
-    let(:response_body) do
-      '{"ok":false,"error":"Unauthorized","error_code":40101}'
-    end
-
     let(:response_status) { 401 }
     let(:response_body) do
       '{"ok":false,"error":"Unauthorized","error_code":40101}'

--- a/spec/lib/airship/api/named_user_associate_email_spec.rb
+++ b/spec/lib/airship/api/named_user_associate_email_spec.rb
@@ -78,30 +78,22 @@ RSpec.describe Airship::Api::NamedUserAssociateEmail do
     subject
   end
 
-  # rubocop:disable RSpec/OverwritingSetup
-  # TODO: Fix this test!
   context 'when failing with HTTP status-code 400 and missing channel' do
     let(:response_status) { 400 }
     let(:response_body) do
-      '{"ok":false,"error":"Unauthorized","error_code":40101}'
-    end
-
-    let(:response_status) { 401 }
-    let(:response_body) do
-      '{"ok":false,"error":"Unauthorized","error_code":40101}'
+      '{"ok":false,"error":"could not find channel"}'
     end
 
     it 'is expected not to succeed' do
-      expect { subject }.to raise_error Airship::Api::Unauthorized
+      expect { subject }.to raise_error Airship::Api::UnexpectedResponseCode
     end
 
     it 'tracks the request and the according error with configured trackers' do
       expect(request_tracker).to receive(:call).with(expected_endpoint)
       expect(error_tracker).to receive(:call).with(expected_endpoint, response_status)
-      expect { subject }.to raise_error Airship::Api::Unauthorized
+      expect { subject }.to raise_error Airship::Api::UnexpectedResponseCode
     end
   end
-  # rubocop:enable RSpec/OverwritingSetup
 
   context 'when responding with any failing HTTP status-code' do
     let(:response_status) { 401 }

--- a/spec/lib/airship/api/named_user_lookup_spec.rb
+++ b/spec/lib/airship/api/named_user_lookup_spec.rb
@@ -108,11 +108,6 @@ RSpec.describe Airship::Api::NamedUserLookup do
       '{"ok":false,"error":"Unauthorized","error_code":40101}'
     end
 
-    let(:response_status) { 401 }
-    let(:response_body) do
-      '{"ok":false,"error":"Unauthorized","error_code":40101}'
-    end
-
     it 'is expected not to succeed' do
       expect { subject }.to raise_error Airship::Api::Unauthorized
     end

--- a/spec/lib/airship/api/named_user_uninstall_spec.rb
+++ b/spec/lib/airship/api/named_user_uninstall_spec.rb
@@ -82,11 +82,6 @@ RSpec.describe Airship::Api::NamedUserUninstall do
       '{"ok":false,"error":"Unauthorized","error_code":40101}'
     end
 
-    let(:response_status) { 401 }
-    let(:response_body) do
-      '{"ok":false,"error":"Unauthorized","error_code":40101}'
-    end
-
     it 'is expected not to succeed' do
       expect { subject }.to raise_error Airship::Api::Unauthorized
     end


### PR DESCRIPTION
`RSpec/OverwritingSetup` violations mean that some lines in the test setup are overwritten and thus have no effect at all on the tests. These lines should be removed because they may obfuscate what's really going on. (I think. I may be wrong. Please enlighten me.)

The test in [`named_user_associate_email_spec.rb`](https://github.com/ioki-mobility/airship-ruby/compare/ebertize-properly?expand=1#diff-c932670ac64a9bd5aa10aa97846703c8d3a5b5be6183c2b096ad1a3c2bad1264) speaks of a `400` response in the description but actually tests a `401`. Can you please check what really want to test here @dal-ioki?