### PR TITLE
v0.1.4: ISO8601 UTC timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [0.1.4] - 2022-09-22
+
+- Transform all is8601 strings to be in UTC
 ## [0.1.3] - 2022-09-20
 
 - Add guard-support for rspec

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    airship-ruby (0.1.3)
+    airship-ruby (0.1.4)
       activesupport (~> 6.1)
       faraday (~> 1.10)
 

--- a/lib/airship/api/custom_event_create.rb
+++ b/lib/airship/api/custom_event_create.rb
@@ -24,7 +24,8 @@ module Airship
 
         [
           {
-            occurred: occurred_at.is_a?(String) ? occurred_at : occurred_at.to_s(:iso8601),
+            # ISO8601 in UTC
+            occurred: occurred,
             user:     {
               named_user_id: named_user_id
             },
@@ -42,6 +43,16 @@ module Airship
         return if additional_payload.values.none? { |v| v.is_a? Hash }
 
         raise ArgumentError, 'additional_payload must not be nested'
+      end
+
+      def occurred
+        time = if occurred_at.is_a?(String)
+                 Time.parse(occurred_at)
+               else
+                 occurred_at
+               end
+
+        time.utc.iso8601
       end
     end
   end

--- a/lib/airship/version.rb
+++ b/lib/airship/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Airship
-  VERSION = '0.1.3'
+  VERSION = '0.1.4'
 end

--- a/spec/lib/airship/api/custom_event_create_spec.rb
+++ b/spec/lib/airship/api/custom_event_create_spec.rb
@@ -103,6 +103,24 @@ RSpec.describe Airship::Api::CustomEventCreate do
     end
   end
 
+  context 'when occured_at gets passed with some Timezone' do
+    context 'as String object' do
+      let(:occurred_at) { Time.zone.local(2020, 3, 13, 17, 30, 45).in_time_zone('Berlin').iso8601 }
+
+      it 'is expected to still use the is08601 string in UTC within the request-footprint' do
+        expect { subject }.not_to raise_error
+      end
+    end
+
+    context 'as DateTime object' do
+      let(:occurred_at) { Time.zone.local(2020, 3, 13, 17, 30, 45).in_time_zone('Berlin') }
+
+      it 'is expected to still use the is08601 string in UTC within the request-footprint' do
+        expect { subject }.not_to raise_error
+      end
+    end
+  end
+
   context 'when additional_paylaod is not a flat object' do
     let(:additional_payload) do
       {


### PR DESCRIPTION
Airship doesn't seem to handle ISO8601 with other timezones anymore. So we have to make sure all incoming timestamps are properly transformed to ISO8601 in UTC
