### PR TITLE
Ignore unrecognized Rubocop cops

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -21,6 +21,7 @@ jobs:
         with:
           rubocop_version: gemfile
           rubocop_extensions: rubocop-rspec:gemfile
+          rubocop_flags: --ignore-unrecognized-cops
           github_token: ${{ secrets.github_token }}
           reporter: github-pr-check
           filter_mode: added

--- a/.rubocop
+++ b/.rubocop
@@ -1,0 +1,1 @@
+--ignore-unrecognized-cops


### PR DESCRIPTION
Prevents rubocop from failing if it encounters new cops in the shared configs that it doesn't know about.