### PR TITLE
Add additional config to dependabot check for GHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,3 +8,11 @@ updates:
       - "dependencies"
     open-pull-requests-limit: 10
     rebase-strategy: "auto"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    open-pull-requests-limit: 10
+    rebase-strategy: "auto"


### PR DESCRIPTION
Daily interval for checking actions should be fine since they don't change too often, but it will result in very fast PRs once a severe problem arises.