### PR TITLE
Fix named user multi request listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## [Unreleased]
 
+## [0.2.1] - 2023-12-22
+- Bugfix: Following named user listings across multiple pages
+
 ## [0.2.0] - 2023-12-21
 - Support for listing (iterating) named users
 

--- a/lib/airship/api/named_users.rb
+++ b/lib/airship/api/named_users.rb
@@ -25,12 +25,12 @@ module Airship
               yield named_user
             end
 
-            break if (named_users.size == 0)
+            break if named_users.size == 0
             break if result['next_page'].nil? || result['next_page'] == ''
 
             uri = URI(result['next_page'])
 
-            additional_query_params = URI::decode_www_form(uri.query).to_h
+            additional_query_params = URI.decode_www_form(uri.query).to_h
           end
         end
       end

--- a/lib/airship/api/named_users.rb
+++ b/lib/airship/api/named_users.rb
@@ -8,20 +8,16 @@ module Airship
       receives :app_key
       receives :token
 
-      receives :page
-      receives :page_size
+      receives :additional_query_params
 
       class << self
         def each(options = {})
           raise ArgumentError, 'argument must be a Hash' unless options.is_a?(Hash)
 
-          page = 0
-          page_size = options[:page_size] || 1000
+          additional_query_params = {}
 
           loop do
-            page += 1
-
-            operation_instance = new(options.merge(page: page, page_size: page_size))
+            operation_instance = new(options.merge(additional_query_params: additional_query_params))
             result = operation_instance.call
             named_users = Array(result['named_users'])
 
@@ -29,7 +25,12 @@ module Airship
               yield named_user
             end
 
-            return if named_users.size < page_size
+            break if (named_users.size == 0)
+            break if result['next_page'].nil? || result['next_page'] == ''
+
+            uri = URI(result['next_page'])
+
+            additional_query_params = URI::decode_www_form(uri.query).to_h
           end
         end
       end
@@ -41,10 +42,7 @@ module Airship
       end
 
       def request_parameters
-        {
-          page:      page || 1,
-          page_size: page_size || 1000
-        }
+        {}.merge(additional_query_params || {})
       end
 
       def process_request

--- a/lib/airship/version.rb
+++ b/lib/airship/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Airship
-  VERSION = '0.2.0'
+  VERSION = '0.2.1'
 end

--- a/spec/lib/airship/api/named_users_spec.rb
+++ b/spec/lib/airship/api/named_users_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Airship::Api::NamedUsers do
             }]
           }
         ],
-        "next_page": "#{described_class::AIRSHIP_API_BASE_URL + expected_endpoint + "?start=wonder.woman"}"
+        "next_page": "#{described_class::AIRSHIP_API_BASE_URL + expected_endpoint + '?start=wonder.woman'}"
       }
     JSON
   end

--- a/spec/lib/airship/api/named_users_spec.rb
+++ b/spec/lib/airship/api/named_users_spec.rb
@@ -19,13 +19,14 @@ RSpec.describe Airship::Api::NamedUsers do
 
   let(:expected_endpoint) { 'named_users' }
   let(:expected_full_path) do
-    described_class::AIRSHIP_API_BASE_URL + expected_endpoint + "?page=#{page}&page_size=#{page_size}"
+    described_class::AIRSHIP_API_BASE_URL + expected_endpoint
   end
 
   let(:response_status) { 200 }
   let(:response_body) do
     <<-JSON
       {
+        "ok": true,
         "named_users": [
           {
             "named_user_id": "harry.potter",
@@ -41,7 +42,8 @@ RSpec.describe Airship::Api::NamedUsers do
                 "device_type": "email"
             }]
           }
-        ]
+        ],
+        "next_page": "#{described_class::AIRSHIP_API_BASE_URL + expected_endpoint + "?start=wonder.woman"}"
       }
     JSON
   end
@@ -112,8 +114,8 @@ RSpec.describe Airship::Api::NamedUsers do
   describe '#each_batch' do
     let(:page_size) { 2 }
 
-    let(:expected_full_path_1) { described_class::AIRSHIP_API_BASE_URL + expected_endpoint + '?page=1&page_size=2' }
-    let(:expected_full_path_2) { described_class::AIRSHIP_API_BASE_URL + expected_endpoint + '?page=2&page_size=2' }
+    let(:expected_full_path_1) { described_class::AIRSHIP_API_BASE_URL + expected_endpoint }
+    let(:expected_full_path_2) { described_class::AIRSHIP_API_BASE_URL + expected_endpoint + '?start=wonder.woman' }
 
     let(:response_body_2) do
       <<-JSON


### PR DESCRIPTION
This resource does not support standard pagination. Because of this the code was broken and would yield the same results again and again. 
Instead this API endpoint will send a "next_page" link along which one is supposed to follow.